### PR TITLE
fix: rename url path to match jsonapi spec

### DIFF
--- a/ebau_gwr/linker/tests/snapshots/snap_test_views.py
+++ b/ebau_gwr/linker/tests/snapshots/snap_test_views.py
@@ -38,8 +38,8 @@ snapshots["test_gwrlink_list 1"] = {
         },
     ],
     "links": {
-        "first": "http://testserver/api/v1/linker/link?page%5Bnumber%5D=1",
-        "last": "http://testserver/api/v1/linker/link?page%5Bnumber%5D=1",
+        "first": "http://testserver/api/v1/linker/gwr-links?page%5Bnumber%5D=1",
+        "last": "http://testserver/api/v1/linker/gwr-links?page%5Bnumber%5D=1",
         "next": None,
         "prev": None,
     },

--- a/ebau_gwr/linker/urls.py
+++ b/ebau_gwr/linker/urls.py
@@ -4,6 +4,6 @@ from . import views
 
 r = SimpleRouter(trailing_slash=False)
 
-r.register(r"link", views.GWRLinkViewSet)
+r.register(r"gwr-links", views.GWRLinkViewSet)
 
 urlpatterns = r.urls


### PR DESCRIPTION
URLs should not only be pluralized, but also match the resource type.