### PR TITLE
feat: allow removal of housing stat credentials

### DIFF
--- a/ebau_gwr/token_proxy/tests/test_views.py
+++ b/ebau_gwr/token_proxy/tests/test_views.py
@@ -89,3 +89,22 @@ def test_token_proxy_external_error(
     resp = admin_client.post(url)
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
     assert resp.json() == {"401": {"reason": "wrong creds", "source": "external"}}
+
+
+def test_token_proxy_remove_creds(db, settings, admin_client, requests_mock):
+    requests_mock.post(
+        f"{settings.GWR_HOUSING_STAT_BASE_URI}/tokenWS/",
+        json={"success": True, "token": "eyIMATOKEN"},
+    )
+    url = reverse("housingstattoken-list")
+    data = {"username": "testy", "password": "test", "municipality": 1234}
+    resp = admin_client.post(
+        url, data=json.dumps(data), content_type="application/json"
+    )
+
+    url = url + "/logout"
+    resp = admin_client.post(url, content_type="application/json")
+    assert resp.status_code == status.HTTP_204_NO_CONTENT
+
+    resp = admin_client.post(url, content_type="application/json")
+    assert resp.status_code == status.HTTP_404_NOT_FOUND

--- a/ebau_gwr/token_proxy/views.py
+++ b/ebau_gwr/token_proxy/views.py
@@ -1,6 +1,9 @@
+from rest_framework import status
+from rest_framework.decorators import action
 from rest_framework.mixins import CreateModelMixin
 from rest_framework.parsers import JSONParser
 from rest_framework.renderers import JSONRenderer
+from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from . import models, serializers
@@ -11,3 +14,14 @@ class TokenProxyView(CreateModelMixin, GenericViewSet):
     queryset = models.HousingStatCreds.objects.all()
     renderer_classes = (JSONRenderer,)
     parser_classes = (JSONParser,)
+
+    @action(detail=False, methods=["post"])
+    def logout(self, request, pk=None):
+        username = request.user.username
+
+        user_creds = models.HousingStatCreds.objects.filter(owner=username)
+        if not user_creds:
+            return Response(None, status=status.HTTP_404_NOT_FOUND)
+
+        user_creds.delete()
+        return Response(None, status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Enable logouts in the gwr application by providing
the necessary functionality to remove stored housing
stat credentials in the database.

Depends on: [ember-ebau-gwr PR](https://github.com/adfinis-sygroup/ember-ebau-gwr/pull/81)